### PR TITLE
switch to pageshow/hide events for bfcache

### DIFF
--- a/src/content-scripts/pageManager.content.js
+++ b/src/content-scripts/pageManager.content.js
@@ -416,13 +416,17 @@ import { fromMonotonicClock } from "../timing.js";
         delete window.pageManagerHasLoaded;
     }
 
-    // Send the page visit start event for the first time
-    pageVisitStart(fromMonotonicClock(window.performance.timeOrigin, false));
+    // Send the page visit start event on the window pageshow event
+    window.addEventListener("pageshow", (event) => {
+        console.log("pageshow");
+        pageVisitStart(fromMonotonicClock(window.performance.timeOrigin, false));
+    })
 
-    // Send the page visit stop event on the window unload event,
-    // using the timestamp for the unload event on the global
+    // Send the page visit stop event on the window pagehide event,
+    // using the timestamp for the pagehide event on the global
     // monotonic clock 
-    window.addEventListener("unload", (event) => {
+    window.addEventListener("pagehide", (event) => {
+        console.log("pagehide");
         pageVisitStop(fromMonotonicClock(event.timeStamp, true));
     });
     

--- a/src/content-scripts/pageManager.content.js
+++ b/src/content-scripts/pageManager.content.js
@@ -418,7 +418,6 @@ import { fromMonotonicClock } from "../timing.js";
 
     // Send the page visit start event on the window pageshow event
     window.addEventListener("pageshow", (event) => {
-        console.log("pageshow");
         pageVisitStart(fromMonotonicClock(window.performance.timeOrigin, false));
     })
 
@@ -426,7 +425,6 @@ import { fromMonotonicClock } from "../timing.js";
     // using the timestamp for the pagehide event on the global
     // monotonic clock 
     window.addEventListener("pagehide", (event) => {
-        console.log("pagehide");
         pageVisitStop(fromMonotonicClock(event.timeStamp, true));
     });
     


### PR DESCRIPTION
This PR adds an event listener for the `pageshow` event and fires a `pageVisitStart` upon an event trigger.

Also, the PR removes the `unload` event and replaces it with `pagehide` to fire a `pageVisitStop`. This is for bfcache compatibility outside of Firefox.

See https://github.com/mozilla-rally/web-science/issues/114 for more.